### PR TITLE
Include .js files in subfolders

### DIFF
--- a/action.js
+++ b/action.js
@@ -30,7 +30,7 @@ async function run(octokit, context) {
 
 	const plugin = new SizePlugin({
 		compression: getInput('compression'),
-		pattern: getInput('pattern') || '**/dist/*.js',
+		pattern: getInput('pattern') || '**/dist/**/*.js',
 		exclude: getInput('exclude') || '{**/*.map,**/node_modules/**}'
 	});
 


### PR DESCRIPTION
This will support a structure such as `/dist/scripts/example.js`.