### PR TITLE
Add option to pass stripHash pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,40 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
+
+### Customizing the Build
+
+By default, `compressed-size-action` will try to build your PR by running the `"build"` [npm script](https://docs.npmjs.com/misc/scripts) in your `package.json`.
+
+If you need to perform some tasks after dependencies are installed but before building, you can use a "postinstall" npm script to do so. For example, in Lerna-based monorepo:
+
+```json
+{
+  "scripts": {
+    "postinstall": "lerna bootstrap",
+    "build": "lerna run build"
+  }
+}
+```
+
+It is also possible to define a `"prebuild"` npm script, which runs after `"postinstall"` but before `"build"`.
+
+You can also specify a completely different [npm script](https://docs.npmjs.com/misc/scripts) to run instead of the default (`"build"`). To do this, add a **`build-script` option** to your `yml` workflow:
+
+```diff
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: preactjs/compressed-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
++       build-script: "ci"
+```

--- a/action.js
+++ b/action.js
@@ -16,9 +16,13 @@ async function fileExists(filename) {
 }
 
 function stripHash(regex) {
-	return function(fileName) {
-		return fileName.replace(regex, '');
+	if (regex) {
+		return function(fileName) {
+			return fileName.replace(new RegExp(regex), '');
+		}
 	}
+
+	return undefined;
 }
 
 

--- a/action.js
+++ b/action.js
@@ -43,7 +43,7 @@ async function run(octokit, context) {
 		compression: getInput('compression'),
 		pattern: getInput('pattern') || '**/dist/**/*.js',
 		exclude: getInput('exclude') || '{**/*.map,**/node_modules/**}',
-		stripHash: stripHash(getInput('stripHash'))
+		stripHash: stripHash(getInput('strip-hash'))
 	});
 
 	console.log(`PR #${pull_number} is targetted at ${pr.base.ref} (${pr.base.sha})`);

--- a/action.js
+++ b/action.js
@@ -17,6 +17,7 @@ async function fileExists(filename) {
 
 function stripHash(regex) {
 	if (regex) {
+		console.log(`Striping hash from build chunks using '${regex}' pattern.`);
 		return function(fileName) {
 			return fileName.replace(new RegExp(regex), '');
 		}

--- a/action.js
+++ b/action.js
@@ -15,6 +15,12 @@ async function fileExists(filename) {
 	return false;
 }
 
+function stripHash(regex) {
+	return function(fileName) {
+		return fileName.replace(regex, '');
+	}
+}
+
 
 async function run(octokit, context) {
 	const { owner, repo, number: pull_number } = context.issue;
@@ -31,7 +37,8 @@ async function run(octokit, context) {
 	const plugin = new SizePlugin({
 		compression: getInput('compression'),
 		pattern: getInput('pattern') || '**/dist/*.js',
-		exclude: getInput('exclude') || '{**/*.map,**/node_modules/**}'
+		exclude: getInput('exclude') || '{**/*.map,**/node_modules/**}',
+		stripHash: stripHash(getInput('stripHash'))
 	});
 
 	console.log(`PR #${pull_number} is targetted at ${pr.base.ref} (${pr.base.sha})`);


### PR DESCRIPTION
Works well in build produced by latest CRA.

```
with:
          repo-token: "${{ secrets.GITHUB_TOKEN }}"
          exclude: "{**/*.map,**/node_modules/**,**/*runtime*.*,**/*manifest*.*,**/*service-worker*.*}"
          pattern: "**/build/**/*.js"
          strip-hash: "\\..*chunk"
```

(delta is shows up as `20` for testing purposes (it's a map on `existing file sizes + 20`))
![image](https://user-images.githubusercontent.com/9931428/75389552-fc7d1680-58e6-11ea-987d-5c894f24e8e1.png)

![image](https://user-images.githubusercontent.com/9931428/75392179-c42c0700-58eb-11ea-9406-0555fd125a5b.png)


related issue: https://github.com/preactjs/compressed-size-action/issues/13
