### PR TITLE
Add threshold option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ inputs:
     default: 'true'
   omit-unchanged:
     description: 'Exclude unchanged files from the sizes table entirely'
+  delta-threshold:
+    description: 'Minimum absolute size change required as condition to report'
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
Having used `compressed-size-action` for some time in the [WordPress/gutenberg](https://github.com/WordPress/gutenberg) project, I've come to the realization that more-often-than-not, I subconsciously ignore the bot's comments. This got me to thinking: What do I want from this bot? To which I consider the following use-cases:

- To flag abnormally large changes in size, particularly when someone may be introducing a new dependency that inflates the built project size ([example](https://github.com/WordPress/gutenberg/pull/18681#issuecomment-557346378)).
- To validate my own efforts targeted specifically at reducing bundle size ([example](https://github.com/WordPress/gutenberg/pull/20693#issuecomment-595978366)).

Both of these use-cases could be satisfied by adding an option to specify a threshold at which a comment should be created. This is what is proposed with these changes.

A couple extra notes:

- Given that the action is responsible not only for creating comments, but also updating them, the condition was limited to occur only when a comment would otherwise be created. This ensures that if there was a previous comment reporting a large size change, subsequent commits to the pull request to bring that size difference back down would be reflected in the comment.
- It occurs to me now that a possible concern with this approach could arise in that: Should a developer be confident in lack of comment signaling "Your changes do not have a substantial impact!" vs. "The comment was unable to be created" (permissions, etc). I suppose this could depend if you view the action as optimized toward creating (default) vs. only reporting abnormalities (edge cases).