### PR TITLE
Fix console output typo

### DIFF
--- a/action.js
+++ b/action.js
@@ -99,7 +99,7 @@ async function run(octokit, context) {
 	await exec(installScript);
 	endGroup();
 
-	startGroup(`[current] Build using ${npm}`);
+	startGroup(`[base] Build using ${npm}`);
 	await exec(`${npm} run ${buildScript}`);
 	endGroup();
 


### PR DESCRIPTION
This looks like a copy-paste issue. This step is building the "base" commit, not the "current" commit, that was already built above.