### PR TITLE
Improve diff table

### DIFF
--- a/tests/__snapshots__/utils.spec.js.snap
+++ b/tests/__snapshots__/utils.spec.js.snap
@@ -90,6 +90,27 @@ exports[`diffTable 5`] = `
 exports[`diffTable 6`] = `
 "**Size Change:** 0 B 
 
+**Total Size:** 4.8 kB
+
+
+
+<details><summary>ℹ️ <strong>View Unchanged</strong></summary>
+
+| Filename | Size | Change |
+| :--- | :---: | :---: |
+| \`one.js\` | 5 kB | 0 B |
+| \`two.js\` | -5 kB | 0 B |
+| \`three.js\` | 300 B | 0 B |
+| \`four.js\` | 4.5 kB | 0 B |
+
+</details>
+
+"
+`;
+
+exports[`diffTable 7`] = `
+"**Size Change:** 0 B 
+
 **Total Size:** 300 B
 
 

--- a/tests/__snapshots__/utils.spec.js.snap
+++ b/tests/__snapshots__/utils.spec.js.snap
@@ -5,18 +5,17 @@ exports[`diffTable 1`] = `
 
 **Total Size:** 4.8 kB
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
+| Filename | Size | Change |  |
+| :--- | :---: | :---: | :---: |
 | \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
 | \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
 | \`four.js\` | 4.5 kB | +9 B (0%) |  |
 
 <details><summary>ℹ️ <strong>View Unchanged</strong></summary>
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
-| \`three.js\` | 300 B | 0 B |  |
-
+| Filename | Size | Change |
+| :--- | :---: | :---: |
+| \`three.js\` | 300 B | 0 B |
 
 </details>
 
@@ -24,18 +23,17 @@ exports[`diffTable 1`] = `
 `;
 
 exports[`diffTable 2`] = `
-"| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
+"| Filename | Size | Change |  |
+| :--- | :---: | :---: | :---: |
 | \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
 | \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
 | \`four.js\` | 4.5 kB | +9 B (0%) |  |
 
 <details><summary>ℹ️ <strong>View Unchanged</strong></summary>
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
-| \`three.js\` | 300 B | 0 B |  |
-
+| Filename | Size | Change |
+| :--- | :---: | :---: |
+| \`three.js\` | 300 B | 0 B |
 
 </details>
 
@@ -47,13 +45,12 @@ exports[`diffTable 3`] = `
 
 **Total Size:** 4.8 kB
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
+| Filename | Size | Change |  |
+| :--- | :---: | :---: | :---: |
 | \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
 | \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
 | \`three.js\` | 300 B | 0 B |  |
-| \`four.js\` | 4.5 kB | +9 B (0%) |  |
-"
+| \`four.js\` | 4.5 kB | +9 B (0%) |  |"
 `;
 
 exports[`diffTable 4`] = `
@@ -61,12 +58,11 @@ exports[`diffTable 4`] = `
 
 **Total Size:** 4.8 kB
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
+| Filename | Size | Change |  |
+| :--- | :---: | :---: | :---: |
 | \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
 | \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
-| \`four.js\` | 4.5 kB | +9 B (0%) |  |
-"
+| \`four.js\` | 4.5 kB | +9 B (0%) |  |"
 `;
 
 exports[`diffTable 5`] = `
@@ -74,18 +70,17 @@ exports[`diffTable 5`] = `
 
 **Total Size:** 4.8 kB
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
+| Filename | Size | Change |  |
+| :--- | :---: | :---: | :---: |
 | \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
 | \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
 
 <details><summary>ℹ️ <strong>View Unchanged</strong></summary>
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
-| \`three.js\` | 300 B | 0 B |  |
-| \`four.js\` | 4.5 kB | +9 B (0%) |  |
-
+| Filename | Size | Change |
+| :--- | :---: | :---: |
+| \`three.js\` | 300 B | 0 B |
+| \`four.js\` | 4.5 kB | +9 B (0%) |
 
 </details>
 
@@ -98,12 +93,12 @@ exports[`diffTable 6`] = `
 **Total Size:** 300 B
 
 
+
 <details><summary>ℹ️ <strong>View Unchanged</strong></summary>
 
-| Filename | Size | Change | |
-|:--- |:---:|:---:|:---:|
-| \`three.js\` | 300 B | 0 B |  |
-
+| Filename | Size | Change |
+| :--- | :---: | :---: |
+| \`three.js\` | 300 B | 0 B |
 
 </details>
 

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -55,6 +55,7 @@ test('diffTable', () => {
 	expect(diffTable(files, { ...defaultOptions, collapseUnchanged: false })).toMatchSnapshot();
 	expect(diffTable(files, { ...defaultOptions, omitUnchanged: true })).toMatchSnapshot();
 	expect(diffTable(files, { ...defaultOptions, minimumChangeThreshold: 10 })).toMatchSnapshot();
+	expect(diffTable(files.map(file => ({...file, delta: 0})), { ...defaultOptions })).toMatchSnapshot();
 
 	expect(diffTable([files[2]], { ...defaultOptions })).toMatchSnapshot();
 });


### PR DESCRIPTION
Don't show empty icon column.

In order to filter these columns out, I also refactor how the table renders.

## Before

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
| \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
| \`four.js\` | 4.5 kB | +9 B (0%) |  |

<details open><summary>ℹ️ <strong>View Unchanged</strong></summary>

| Filename | Size | Change | |
| :--- | :---: | :---: |:---: |
| \`three.js\` | 300 B | 0 B | |

</details>

## After

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| \`one.js\` | 5 kB | +2.5 kB (50%) | 🆘 |
| \`two.js\` | -5 kB | -2.5 kB (50%) | 🆘 |
| \`four.js\` | 4.5 kB | +9 B (0%) |  |

<details open><summary>ℹ️ <strong>View Unchanged</strong></summary>

| Filename | Size | Change |
| :--- | :---: | :---: |
| \`three.js\` | 300 B | 0 B |

</details>

