### PR TITLE
exec git reset after build to prevent git-diff between builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,9 @@ async function run(octokit, context, token) {
 	await exec(`${npm} run ${buildScript}`);
 	endGroup();
 
+        // In case the build step alters a JSON-file, ....
+        await exec(`git reset --hard`);
+
 	const oldSizes = await plugin.readFromDisk(cwd);
 
 	const diff = await plugin.getDiff(oldSizes, newSizes);

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,9 @@ async function run(octokit, context, token) {
 	console.log(`Building using ${npm} run ${buildScript}`);
 	await exec(`${npm} run ${buildScript}`);
 	endGroup();
+	
+	// In case the build step alters a JSON-file, ....
+        await exec(`git reset --hard`);
 
 	const newSizes = await plugin.readFromDisk(cwd);
 


### PR DESCRIPTION
We're having this issue in a [Preact PR](https://github.com/preactjs/preact/pull/2627/checks?check_run_id=1077479267#step:3:354) atm this because `yarn build` sometimes changes spacing in `mangle.json`.