### PR TITLE
Update action.yml to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ inputs:
   cwd:
     description: 'A custom working directory to execute the action in relative to repo root (defaults to .)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
My repo has started getting this warning:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: preactjs/compressed-size-action`

This PR updates `action.yml` to use node16
