### PR TITLE
Allow configuring an installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,44 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
 ```
 
+### Customizing Package Installation
+
+By default, `compressed-size-action` will install dependencies according to your package manager:
+
+- **npm**, without `package-lock.json`: `npm install`
+- **npm**, with `package-lock.json`: `npm ci`
+- **pnpm**: `pnpm install --frozen-lockfile`
+- **yarn**: `yarn --frozen-lockfile`
+
+If you need to run a different installation command, you can use a custom npm script to do so. For example, to use `npm ci` with the `--workspace` option:
+
+```json
+{
+  "scripts": {
+    "install-deps": "npm ci --workspace=packages/my-subpackage",
+  }
+}
+```
+
+This script must be specified as the `install-script` option:
+
+```diff
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: preactjs/compressed-size-action@v2
+      with:
++       install-script: "install-deps"
+```
+
 ### Customizing the Build
 
 By default, `compressed-size-action` will try to build your PR by running the `"build"` [npm script](https://docs.npmjs.com/misc/scripts) in your `package.json`.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
     default: ${{ github.token }}
   clean-script:
     description: 'An npm-script that cleans/resets state between branch builds'
+  install-script:
+    description: 'The npm-script to run that installs your project'
   build-script:
     description: 'The npm-script to run that builds your project'
     default: 'build'

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ async function run(octokit, context, token) {
 		installScript = 'npm ci';
 	}
 
-	const configInstallScript = getInput('install-script');
+	let configInstallScript = getInput('install-script');
 	if (configInstallScript) {
 		installScript = `${packageManager} run ${configInstallScript}`;
 	}
@@ -138,6 +138,11 @@ async function run(octokit, context, token) {
 		packageManager = `pnpm`;
 	} else if (packageLock) {
 		installScript = `npm ci`;
+	}
+
+	configInstallScript = getInput('install-script');
+	if (configInstallScript) {
+		installScript = `${packageManager} run ${configInstallScript}`;
 	}
 
 	console.log(`Installing using ${installScript}`);

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,11 @@ async function run(octokit, context, token) {
 		installScript = 'npm ci';
 	}
 
+	const configInstallScript = getInput('install-script');
+	if (configInstallScript) {
+		installScript = `${packageManager} run ${configInstallScript}`;
+	}
+
 	startGroup(`[current] Install Dependencies`);
 	console.log(`Installing using ${installScript}`);
 	await exec(installScript);


### PR DESCRIPTION
In some environments, an installation script must be specified to limit the amount of dependencies.

We have a monorepo in our case, in which the build dependencies are scoped to different packages.

As a result, `npm ci` is **much** slower than our custom build-only install script. A full install takes about ~60s, whereas a build-only install takes about ~5s. Our builds take less than 5s, so the ability to configure install would reduce our total time to run `compressed-size-action` from ~130s to less than 20s.