### PR TITLE
chore: Update Github actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
The Github actions `actions/checkout@v2` and `actions/setup-node@v1` need to be updated to the latest versions to be in compliance with Github's node@12 deprecation. I believe the following warning is due to these actions being out of date.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: preactjs/compressed-size-action@2.5.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

I don't think https://github.com/preactjs/compressed-size-action/pull/87 fully solved this problem

From the link:
> Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases), as a result we have started the deprecation process of Node 12 for GitHub Actions. We plan to migrate all actions to run on Node16 by Summer 2023. We will monitor the progress of the migration and listen to the community for how things are going before we define a final date.
To raise awareness of the upcoming change, we are adding a warning into workflows which contain Actions running on Node 12. This will come into effect starting on September 27th.

In my own projects I updated these actions to the latest major versions and the deprecation warning went away.

I imagine this change would be a major version upgrade as I had to add these new versions to my project's allowed list of actions, otherwise I receive this warning and the actions fail to execute.
> Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following < list of existing actions >