### PR TITLE
Update actions/setup-node from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
to fix this warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: preactjs/compressed-size-action@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.