### PR TITLE
fix: Incorrect fetch for `baseRef`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ async function run(octokit, context, token) {
 	startGroup(`[base] Checkout target branch`);
 	try {
 		if (!baseRef) throw Error('missing context.payload.pull_request.base.ref');
-		await exec(`git fetch -n origin ${baseRef}`);
+		await exec(`git fetch -n origin ${baseRef}:${baseRef}`);
 		console.log('successfully fetched base.ref');
 	} catch (e) {
 		console.log('fetching base.ref failed', e.message);


### PR DESCRIPTION
```
/usr/bin/git fetch -n origin main
  From https://github.com/preactjs/preact
   * branch              main       -> FETCH_HEAD
   * [new branch]        main       -> origin/main
  successfully fetched base.ref
  checking out and building base commit
  /usr/bin/git reset --hard main
  fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
```

- [Logs](https://github.com/preactjs/preact/actions/runs/11016375323/job/30591720503)

As the repo is a shallow clone, fetches will only update the remote branch tracking the currently cloned branch, i.e., `git fetch <another branch>` won't have any effect. Providing a local branch to track the remote from will fix this, however.

Simple demonstration of the issue:

```sh
git clone git@github.com:preactjs/preact.git --depth=1
cd preact
git fetch -n origin v11 # fetch will succeed, but not affect the repo
git reset --hard v11 # will fail with the same error as shown above

git fetch -n origin v11:v11
git reset --hard v11 # will succeed
```