### PR TITLE
fix: Filter defaults not working as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Files are collected by finding matches for `pattern`, then any of those that mat
 ```yaml
 with:
   # Any JS files anywhere within a dist directory:
-  pattern: "**/dist/**/*.js"
+  pattern: "**/dist/**/*.{js,mjs,cjs}"
 
   # Always ignore SourceMaps and node_modules:
   exclude: "{**/*.map,**/node_modules/**}"

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,8 @@ inputs:
     default: 1
   pattern:
     description: 'minimatch pattern of files to track'
-    default:  '**/dist/**/*.js'
   exclude:
     description: 'minimatch pattern of files NOT to track'
-    default: '{**/*.map,**/node_modules/**}'
   cwd:
     description: 'A custom working directory to execute the action in relative to repo root (defaults to .)'
   comment-key:


### PR DESCRIPTION
Re: https://github.com/preactjs/preact/pull/4652#discussion_r1954397277

14f22a18a0dcb81bb21fe7c5ef42fad138686dc2 bumped the default pattern from the JS script, but not in the action config, ergo, it was entirely ignored as the action always provided an input here.

https://github.com/preactjs/compressed-size-action/blob/6fa0e7ca017120c754863b31123c5ee2860fd434/src/index.js#L45

Alternatively, we could drop the fallbacks from the JS script & move them into the action config. However, I imagine the option this PR takes is preferable for testing purposes as we don't have to copy the values from the YML file into our test config.