### PR TITLE
fix: Ensure newly-added files show up as 'changed'

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -201,7 +201,7 @@ export function diffTable(files, { showTotal, collapseUnchanged, omitUnchanged, 
 		totalDelta += delta;
 
 		const originalSize = size - delta;
-		const isUnchanged = Math.abs(delta) < minimumChangeThreshold;
+		const isUnchanged = Math.abs(delta) < minimumChangeThreshold && originalSize !== 0;
 
 		if (isUnchanged && omitUnchanged) continue;
 


### PR DESCRIPTION
Seeing this issue [here](https://github.com/preactjs/preact-custom-element/pull/120#issuecomment-3445755480) where a newly-added file lands in the "unchanged" list when it shouldn't.

The file should only be unchanged if there's a delta of 0 AND the original size is not 0:

https://github.com/preactjs/compressed-size-action/blob/98b0edc946e6864bcd28dca9e3eed8f5618b1a82/src/utils.js#L82-L83