### PR TITLE
refactor: Move 'clean' script call to target branch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,13 @@ async function run(octokit, context, token) {
 		}
 	}
 
+	const cleanScript = getInput('clean-script');
+	if (cleanScript) {
+		startGroup(`[target] Cleanup via ${packageManager} run ${cleanScript}`);
+		await exec(`${packageManager} run ${cleanScript}`);
+		endGroup();
+	}
+
 	console.log('checking out and building base commit');
 	try {
 		if (!baseRef) throw Error('missing context.payload.base.ref');
@@ -98,12 +105,6 @@ async function run(octokit, context, token) {
 	}
 	endGroup();
 
-	const cleanScript = getInput('clean-script');
-	if (cleanScript) {
-		startGroup(`[base] Cleanup via ${packageManager} run ${cleanScript}`);
-		await exec(`${packageManager} run ${cleanScript}`);
-		endGroup();
-	}
 
 	startGroup(`[base] Install Dependencies`);
 


### PR DESCRIPTION
Relatively minor but improves DX and reduces headaches considerably, IMO.

The issue with running the `clean` script against the base branch, rather than target, is that it's always a PR behind; I can't add a new `clean` script in my `package.json` AND tell compressed-size to use it all in one go, as the new script will only exist on the target branch & NPM will error out when trying to run it on the base.

I think moving it up so that it's the last action ran against the target branch, instead of the first against the base, makes far more sense and makes it easier for users to make changes like this. Users will be able to edit their action config & scripts to keep them in-sync all at once.