### PR TITLE
fix: avoid double npm run commands if build-script is given as input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,19 @@ async function run(octokit, context, token) {
 
 	const newSizes = await plugin.readFromDisk(cwd);
 
+	function throwIfBaseRefMissing() {
+		if (!baseRef) {
+			if (context.eventName == 'push') {
+				throw new Error('missing context.payload.base.ref for push event');
+			} else {
+				throw new Error('missing context.payload.pull_request.base.ref for pull_request event');
+			}
+		}
+	}
+
 	startGroup(`[base] Checkout target branch`);
 	try {
-		if (!baseRef) throw Error('missing context.payload.pull_request.base.ref');
+		throwIfBaseRefMissing();
 		await exec(`git fetch -n origin ${baseRef}:${baseRef}`);
 		console.log('successfully fetched base.ref');
 	} catch (e) {
@@ -99,7 +109,7 @@ async function run(octokit, context, token) {
 
 	console.log('checking out and building base commit');
 	try {
-		if (!baseRef) throw Error('missing context.payload.base.ref');
+		throwIfBaseRefMissing();
 		await exec(`git reset --hard ${baseRef}`);
 	} catch (e) {
 		await exec(`git reset --hard ${baseSha}`);


### PR DESCRIPTION
this screenshot is from preact repo's ci. 

notice `... npm run npm run --if-present noop`

<img width="720" height="71" alt="Screenshot 1404-12-04 at 00 43 01" src="https://github.com/user-attachments/assets/f6ebd373-e480-4199-8b6d-27950e4c2e87" />
