### PR TITLE
Make it clear that this is not suitable for forked PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub action that reports changes in compressed file sizes on your PRs.
 
 <img width="600" src="https://user-images.githubusercontent.com/105127/73027489-8413c900-3e01-11ea-8630-09172b247f82.png">
 
-### Usage:
+### Usage [Internal PRs in same repo]:
 
 Add a workflow (`.github/workflows/main.yml`):
 
@@ -28,6 +28,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
 ```
+
+### Usage [External PRs from forks]:
+
+There is no secure way to run this action as a single step when comparing an external PR from a fork, as it would need `pull_request_target` 
+permission to post the comment.  See #54 for more info, there is a two step workaround possible whereby a json artifact is generated in a
+first step (pull_request), and posted as a comment in the forked pr in the second step (pull_request_target).
+
 
 ### Customizing the Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub action that reports changes in compressed file sizes on your PRs.
 
 <img width="600" src="https://user-images.githubusercontent.com/105127/73027489-8413c900-3e01-11ea-8630-09172b247f82.png">
 
-### Usage [Internal PRs in same repo]:
+### Usage:
 
 Add a workflow (`.github/workflows/main.yml`):
 
@@ -29,12 +29,7 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
 ```
 
-### Usage [External PRs from forks]:
-
-There is no secure way to run this action as a single step when comparing an external PR from a fork, as it would need `pull_request_target` 
-permission to post the comment.  See #54 for more info, there is a two step workaround possible whereby a json artifact is generated in a
-first step (pull_request), and posted as a comment in the forked pr in the second step (pull_request_target).
-
+> **Note:** Due to GitHub's permission model, this action cannot safely create comments when it is triggered by a PR from a fork. It will, however, still generate the size comparison and print the comment it would've posted to the stdout of the action, allowing manual checking and you can copy/paste it into a comment if you wish.
 
 ### Customizing the Installation
 


### PR DESCRIPTION
The README does not mention that the action doesn't work for fork PRs.  Another developer added this to our repo and I later 'fixed' the fact that the comments weren't showing up by elevating the permissions, not knowing that there were security implications.  The 2-step workaround in #54 should really be the primary installation method with a 'by the way if you know what you are doing, you can do it in one step' note at the bottom of the readme ... I can attempt that write up but I'd need to delve into this action more, and I think maybe there are others who know how to do this better