### PR TITLE
fix: Ignore unchanged files when calculating delta

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -198,10 +198,11 @@ export function diffTable(files, { showTotal, collapseUnchanged, omitUnchanged, 
 	for (const file of files) {
 		const { filename, size, delta } = file;
 		totalSize += size;
-		totalDelta += delta;
 
 		const originalSize = size - delta;
 		const isUnchanged = Math.abs(delta) < minimumChangeThreshold;
+
+		if (!isUnchanged) totalDelta += delta;
 
 		if (isUnchanged && omitUnchanged) continue;
 

--- a/tests/__snapshots__/utils.spec.js.snap
+++ b/tests/__snapshots__/utils.spec.js.snap
@@ -85,7 +85,7 @@ exports[`diffTable 4`] = `
 `;
 
 exports[`diffTable 5`] = `
-"**Size Change:** +9 B (+0.04%) 
+"**Size Change:** 0 B 
 
 **Total Size:** 21.3 kB
 


### PR DESCRIPTION
Closes #137

The delta from within "Unchanged files" isn't supposed to be meaningful, especially as gzip/brotli sizes are not deterministic -- variation of 0-10b is very normal, hence our `minimum-change-threshold` option. As such, the current behavior becomes a bit problematic in larger apps as (for example) 80 files * 1-10b each results in a sizable delta that doesn't actually exist.

The updated test case is actually a good example of the issue