### PR TITLE
feat: add base-ref input to override PR base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,33 +205,8 @@ compression: "none"
 
 Use the `base-ref` option to compare against a specific ref. Otherwise, the action compares against the PR's base branch.
 
-```diff
-name: Compressed Size
-on: [pull_request]
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: preactjs/compressed-size-action@v2
-      with:
-+       base-ref: "v1.2.0"
-```
 
-Eg, a project could set `base-ref` conditionally to use the default PR base branch for feature PRs, but compare against `production` for release PRs (e.g. those opened by [release-please](https://github.com/googleapis/release-please)). This is useful for release PRs that only represent a version bump and wouldn't produce a meaningful size comparison. Comparing against the previous release tag instead shows cumulative size change across all changes going into the release.
-
-```yaml
-name: Compressed Size
-on: [pull_request]
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: preactjs/compressed-size-action@v2
-      with:
-        base-ref: ${{ startsWith(github.head_ref, 'release-please--') && 'production' || '' }}
-```
+For example, a project could set `base-ref` conditionally to use the PR target branch for feature PRs but compare against `production` for release PRs. Comparing against the previous release tag could show cumulative size change across all changes going into the release.
 
 ### Checking multiple bundles
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,38 @@ By default, files are compared after gzip compression, but it's possible to use 
 compression: "none"
 ```
 
+### Specifying the base ref
+
+Use the `base-ref` option to compare against a specific ref. Otherwise, the action compares against the PR's base branch.
+
+```diff
+name: Compressed Size
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: preactjs/compressed-size-action@v2
+      with:
++       base-ref: "v1.2.0"
+```
+
+Eg, a project could set `base-ref` conditionally to use the default PR base branch for feature PRs, but compare against `production` for release PRs (e.g. those opened by [release-please](https://github.com/googleapis/release-please)). This is useful for release PRs that only represent a version bump and wouldn't produce a meaningful size comparison. Comparing against the previous release tag instead shows cumulative size change across all changes going into the release.
+
+```yaml
+name: Compressed Size
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: preactjs/compressed-size-action@v2
+      with:
+        base-ref: ${{ startsWith(github.head_ref, 'release-please--') && 'production' || '' }}
+```
+
 ### Checking multiple bundles
 
 The action reuses the same comment each time it runs on a PR. In order to run the action multiple times against separate bundles for a single PR, you must provide a `comment-key` option, which the action will use to determine which comment to add or update for the run. The example below demonstrates this for separate "modern" and "legacy" bundles:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'The GITHUB_TOKEN secret'
     required: false
     default: ${{ github.token }}
+  base-ref:
+    description: 'A specific git ref (branch, tag, or SHA) to compare against instead of the PR base branch'
+    required: false
   clean-script:
     description: 'An npm-script that cleans/resets state between branch builds'
   install-script:

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ async function run(octokit, context, token) {
 
 	const inputBaseRef = getInput('base-ref');
 	if (inputBaseRef) {
-		console.log(`Overriding base ref with input base-ref: ${inputBaseRef}`);
+		console.log(`Setting base ref to: "${inputBaseRef}"`);
 		baseRef = inputBaseRef;
 		// fallback base sha doesn't make sense if given an explicit base ref:
 		baseSha = null;

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,14 @@ async function run(octokit, context, token) {
 		);
 	}
 
+	const inputBaseRef = getInput('base-ref');
+	if (inputBaseRef) {
+		console.log(`Overriding base ref with input base-ref: ${inputBaseRef}`);
+		baseRef = inputBaseRef;
+		// fallback base sha doesn't make sense if given an explicit base ref:
+		baseSha = null;
+	}
+
 	if (getInput('cwd')) process.chdir(getInput('cwd'));
 
 	const plugin = new SizePlugin({
@@ -76,15 +84,19 @@ async function run(octokit, context, token) {
 		console.log('successfully fetched base.ref');
 	} catch (e) {
 		console.log('fetching base.ref failed', e.message);
-		try {
-			await exec(`git fetch -n origin ${baseSha}`);
-			console.log('successfully fetched base.sha');
-		} catch (e) {
-			console.log('fetching base.sha failed', e.message);
+		if (baseSha === null) {
+			throw new Error('base.ref fetch failed and no base.sha as fallback');
+		} else {
 			try {
-				await exec(`git fetch -n`);
+				await exec(`git fetch -n origin ${baseSha}`);
+				console.log('successfully fetched base.sha');
 			} catch (e) {
-				console.log('fetch failed', e.message);
+				console.log('fetching base.sha failed', e.message);
+				try {
+					await exec(`git fetch -n`);
+				} catch (e) {
+					console.log('fetch failed', e.message);
+				}
 			}
 		}
 	}
@@ -101,6 +113,7 @@ async function run(octokit, context, token) {
 		if (!baseRef) throw Error('missing context.payload.base.ref');
 		await exec(`git reset --hard ${baseRef}`);
 	} catch (e) {
+		if (!baseSha) throw e;
 		await exec(`git reset --hard ${baseSha}`);
 	}
 	endGroup();


### PR DESCRIPTION
Closes #145.

## Summary
- Adds a `base-ref` action input that overrides the PR base branch when resolving the comparison ref
- When set, `baseSha` is nulled so fallback logic doesn't re-use the PR's `base.sha`
- Null guards on the fetch and reset fallbacks surface a clear error instead of running `git ... null`
- README example shows a release-please conditional: default PR base for feature PRs, `production` for release PRs