### PR TITLE
feat: add `comment-body` output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: 'The column and direction to sort the results by. The format is "column:direction", where column is one of "Filename", "Size", or "Change" and direction is "asc" or "desc". For example, "Size:desc" sorts the table by file size in descending order.'
     default: 'Filename:asc'
 
+outputs:
+  comment-body:
+    description: 'The full Markdown body the action posts to the PR, including the size report and footer.'
+
 runs:
   using: 'node24'
   main: 'index.js'

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { getInput, setFailed, startGroup, endGroup, debug } from '@actions/core'
 import { context, getOctokit } from '@actions/github';
 import { exec } from '@actions/exec';
 import { SizePlugin } from '@rschristian/size-plugin';
-import { getPackageManagerAndInstallScript, diffTable, toBool, stripHash, getSortOrder } from './utils.js';
+import { getPackageManagerAndInstallScript, diffTable, toBool, stripHash, getSortOrder, setOutput } from './utils.js';
 
 /**
  * @typedef {ReturnType<typeof import("@actions/github").getOctokit>} Octokit
@@ -169,6 +169,8 @@ async function run(octokit, context, token) {
 			markdownDiff +
 			`\n\n<a href="https://github.com/preactjs/compressed-size-action"><sub>compressed-size-action${commentKey ? `::${commentKey}` : ''}</sub></a>`
 	};
+
+	setOutput('comment-body', comment.body);
 
 	if (context.eventName !== 'pull_request' && context.eventName !== 'pull_request_target') {
 		console.log('No PR associated with this action run. Not posting a check or comment.');

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { EOL } from 'os';
 import prettyBytes from 'pretty-bytes';
 
 /**
@@ -268,4 +269,23 @@ export function getSortOrder(sortBy) {
 	}
 	console.warn(`Invalid 'order-by' value '${sortBy}', defaulting to 'Filename:asc'`);
 	return 'Filename:asc';
+}
+
+/**
+ * 
+ * @param {string} name
+ * @param {string} value
+ */
+export function setOutput(name, value) {
+	const outputPath = process.env.GITHUB_OUTPUT;
+
+	if (outputPath) {
+		const delimiter = `ghadelimiter_${Date.now()}`;
+		fs.appendFileSync(outputPath, `${name}<<${delimiter}${EOL}${value}${EOL}${delimiter}${EOL}`);
+		return;
+	}
+
+	console.log(
+		`::set-output name=${name}::${String(value).replace(/\n/g, '%0A').replace(/\r/g, '%0D')}`
+	);
 }


### PR DESCRIPTION
Releted: https://github.com/preactjs/compressed-size-action/issues/2#issuecomment-4341632581

Write the results to `outputs` so downstream workflows can manage comments on their own. For example, the results can be uploaded as artifacts, and a `workflow_run` with write permissions can then post comments on PRs from forks.


<details><summary>Compressed Size Comment Body</summary>

```yaml
name: Compressed Size Comment Body

on:
  pull_request:

jobs:
  size:
    runs-on: ubuntu-latest

    steps:
      - id: compressed-size
        uses: preactjs/compressed-size-action@v2
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}

      - name: Save comment body
        env:
          COMMENT_BODY: ${{ steps.compressed-size.outputs.comment-body }}
        run: printf '%s\n' "$COMMENT_BODY" > compressed-size-comment.md

      - uses: actions/upload-artifact@v4
        with:
          name: compressed-size-comment
          path: compressed-size-comment.md
```
</details> 

<details><summary>Compressed Size Comment Post</summary>

```yaml
name: Compressed Size Comment Post

on:
  workflow_run:
    workflows: ['Compressed Size Comment Body']
    types: [completed]

jobs:
  comment:
    runs-on: ubuntu-latest
    permissions:
      pull-requests: write

    steps:
      - uses: dawidd6/action-download-artifact@v21
        with:
          workflow: ${{ github.event.workflow.id }}
          run_id: ${{ github.event.workflow_run.id }}
          name: compressed-size-comment

      - id: comment
        run: |
          {
            echo 'body<<EOF'
            cat compressed-size-comment.md
            echo EOF
          } >> "$GITHUB_OUTPUT"

      - uses: actions-cool/maintain-one-comment@v3.3.0
        with:
          body: ${{ steps.comment.outputs.body }}
          body-include: '<!-- compressed-size-action -->'
          number: ${{ github.event.pull_request.number }}
```
</details> 
