### PR TITLE
ci: set explicit read permissions on ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   build_test:
     name: Build & Test


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/ci.yml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.